### PR TITLE
Add support for the `tagStandard41h12` family

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,4 +1,4 @@
-@enum TagFamilies tag36h11 tag25h9 tag16h5
+@enum TagFamilies tag36h11 tag25h9 tag16h5 tagStandard41h12 #tagStandard52h13 #tagCircle49h12
 
 """
     $(TYPEDEF)
@@ -115,6 +115,12 @@ function AprilTagDetector(tagfamily::TagFamilies = tag36h11)
         tf = tag25h9_create()
     elseif tagfamily == tag16h5
         tf = tag16h5_create()
+    elseif tagfamily == tagStandard41h12
+        tf = tagStandard41h12_create()
+    # elseif tagfamily == tagStandard52h13
+    #     tf = tagStandard52h13_create()
+    # elseif tagfamily == tagCircle49h12
+    #     tf = tagCircle49h12_create()
     end
 
     #add family to detector
@@ -313,6 +319,12 @@ function  getAprilTagImage(tagIndex::Int, tagfamily::TagFamilies = tag36h11; bla
         tf = tag25h9_create()
     elseif tagfamily == tag16h5
         tf = tag16h5_create()
+    elseif tagfamily == tagStandard41h12
+        tf = tagStandard41h12_create()
+    # elseif tagfamily == tagStandard52h13
+    #     tf = tagStandard52h13_create()
+    # elseif tagfamily == tagCircle49h12
+    #     tf = tagCircle49h12_create()
     end
 
     tagptr = AprilTags.apriltag_to_image(tf, Int32(tagIndex))

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -359,6 +359,32 @@ function tag16h5_destroy(tf)
     ccall((:tag16h5_destroy, libapriltag), Nothing, (Ptr{apriltag_family_t},), tf)
 end
 
+function tagStandard41h12_create()
+    ccall((:tagStandard41h12_create, libapriltag), Ptr{apriltag_family_t}, ())
+end
+
+function tagStandard41h12_destroy(tf)
+    ccall((:tagStandard41h12_destroy, libapriltag), Nothing, (Ptr{apriltag_family_t},), tf)
+end
+
+# # this family segfaults for `apriltag_detector_add_family(td, tf)
+# function tagStandard52h13_create()
+#     ccall((:tagStandard52h13_create, libapriltag), Ptr{apriltag_family_t}, ())
+# end
+#
+# function tagStandard52h13_destroy(tf)
+#     ccall((:tagStandard52h13_destroy, libapriltag), Nothing, (Ptr{apriltag_family_t},), tf)
+# end
+
+# # circular tags are problematic because they require a mask of white pixels around the circle
+# function tagCircle49h12_create()
+#     ccall((:tagCircle49h12_create, libapriltag), Ptr{apriltag_family_t}, ())
+# end
+#
+# function tagCircle49h12_destroy(tf)
+#     ccall((:tagCircle49h12_destroy, libapriltag), Nothing, (Ptr{apriltag_family_t},), tf)
+# end
+
 """
 	apriltag_detector_create()
 Create a AprilTag Detector object with all fields set to default value.

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -155,6 +155,12 @@ using Test
         detector2 = AprilTagDetector(AprilTags.tag36h11)
         freeDetector!(detector2)
 
+        detector2 = AprilTagDetector(AprilTags.tagStandard41h12)
+        freeDetector!(detector2)
+
+        # detector2 = AprilTagDetector(AprilTags.tagStandard52h13)
+        # freeDetector!(detector2)
+
         # detector2 = AprilTagDetector(AprilTags.tag36h10)
         # freeDetector!(detector2)
 
@@ -202,6 +208,17 @@ using Test
                                     1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0;
                                     1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0]
         @test reftag25h9_0 == getAprilTagImage(0, AprilTags.tag25h9)
+
+        reftagStandard41h12_0 = Gray{N0f8}[1.0 1.0 0.0 1.0 1.0 1.0 1.0 0.0 0.0;
+                                           0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0;
+                                           1.0 0.0 1.0 1.0 1.0 1.0 1.0 0.0 0.0;
+                                           0.0 0.0 1.0 1.0 1.0 1.0 1.0 0.0 1.0;
+                                           0.0 0.0 1.0 0.0 0.0 1.0 1.0 0.0 0.0;
+                                           0.0 0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0;
+                                           1.0 0.0 1.0 1.0 1.0 1.0 1.0 0.0 0.0;
+                                           0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0;
+                                           1.0 1.0 0.0 1.0 0.0 0.0 1.0 0.0 0.0]
+        @test reftagStandard41h12_0 == getAprilTagImage(0, AprilTags.tagStandard41h12, blackborder=false)
 
         # TODO test, just placeholder for now
         detector = AprilTagDetector()


### PR DESCRIPTION
This adds support for the `tagStandard41h12` family.

I encountered two difficulties in attempting to add `tagStandard52h13` as well as `tagCircle49h12`:
- For some reason, `tagStandard52h13` causes a segfault when running `apriltag_detector_add_family(td, tf)`. 
- Circular tags (e.g. `tagCircle49h12`) are problematic because they require a mask of white pixels around the circle, but the pixels outside the circle are black.
